### PR TITLE
Add sort journal entries by date feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,12 @@ This is a VS Code extension called "hledger-formatter" that formats hledger jour
    - `formatTransaction()` - Formats individual transactions
    - `formatTransactionHeader()` - Normalizes transaction header spacing
    - `toggleCommentLines()` - Toggle comments on selected lines (exported for testing)
+   - `sortHledgerJournal()` - Sorts journal entries by date (exported for testing)
 
 2. **Command Registration**:
    - Manual format command: `hledger-formatter.formatDocument`
    - Comment toggle command: `hledger-formatter.toggleComment` (Cmd+/)
+   - Sort entries command: `hledger-formatter.sortEntries` (Shift+Cmd+S)
    - Format-on-save handler for hledger files
    - Document formatting provider (integrates with VS Code's Format Document)
    - Range formatting provider
@@ -81,6 +83,34 @@ Second toggle (uncomments all):
   reconciliation note         ← now uncommented
 ```
 
+### Sort Entries Logic
+
+The sort entries feature (Shift+Cmd+S) sorts journal transactions by date:
+
+**Key Features:**
+- Sorts all transactions chronologically by date
+- Preserves transaction integrity (keeps posting lines with their headers)
+- Maintains leading comments and empty lines before first transaction
+- Preserves spacing between transactions
+- Handles various date formats (YYYY-MM-DD, YYYY/MM/DD)
+
+**Example:**
+```
+Before:
+2025-03-08 Transaction 2
+  Assets:Cash  $200.00
+  
+2025-03-04 Transaction 1
+  Assets:Cash  $100.00
+
+After:
+2025-03-04 Transaction 1
+  Assets:Cash  $100.00
+  
+2025-03-08 Transaction 2
+  Assets:Cash  $200.00
+```
+
 ### Test Structure
 
 Tests are in `src/test/` with input/output journal pairs:
@@ -96,6 +126,10 @@ Tests are in `src/test/` with input/output journal pairs:
 - `comment_mixed_in.journal` / `comment_mixed_out.journal` - Mixed commented/uncommented lines with smart block behavior
 - `comment_indented_in.journal` / `comment_indented_out.journal` - Complex indentation scenarios
 - Unit tests for smart block behavior with mixed comment states
+
+**Sort Tests:**
+- `sort_in.journal` / `sort_out.journal` - Sorting transactions by date
+- Unit tests for transaction integrity and comment preservation
 
 Test verification includes:
 - Exact output matching

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
       {
         "command": "hledger-formatter.toggleComment",
         "title": "Toggle Comment"
+      },
+      {
+        "command": "hledger-formatter.sortEntries",
+        "title": "Sort Journal Entries by Date"
       }
     ],
     "configuration": {
@@ -59,6 +63,11 @@
       {
         "command": "hledger-formatter.toggleComment",
         "key": "cmd+/",
+        "when": "editorTextFocus && (resourceExtname == .journal || resourceExtname == .hledger || resourceExtname == .ledger)"
+      },
+      {
+        "command": "hledger-formatter.sortEntries",
+        "key": "shift+cmd+s",
         "when": "editorTextFocus && (resourceExtname == .journal || resourceExtname == .hledger || resourceExtname == .ledger)"
       }
     ],

--- a/src/test/test_journals/sort_in.journal
+++ b/src/test/test_journals/sort_in.journal
@@ -1,0 +1,26 @@
+; Test file for sorting journal entries
+; These entries are intentionally out of order
+
+2025-03-31 * Reconciled - March 2025
+  ; assets:bank:checking matched statement balance of $93.16
+  ; reconciliation completed Tue Apr 22 10:33:05 EDT 2025
+
+2025-03-08 * Pragmatic Engineer subscription
+  expenses:education                    $15.00
+  assets:bank:checking                 -$15.00
+
+2025-03-04 * Fastmail subscription
+  expenses:software:email               $38.99
+  assets:bank:checking                 -$38.99
+
+2025-03-27 * GitHub subscription
+  expenses:software:github               $4.00
+  assets:bank:checking                  -$4.00
+
+2025-03-07 * App Store sale
+  assets:bank:checking                   $2.47
+  income:sales:apple                    -$2.47
+
+2025-03-07 * Maine Annual LLC Filing
+  expenses:professional:compliance   $185.00
+  equity:owner:contributions        -$185.00

--- a/src/test/test_journals/sort_out.journal
+++ b/src/test/test_journals/sort_out.journal
@@ -1,0 +1,26 @@
+; Test file for sorting journal entries
+; These entries are intentionally out of order
+
+2025-03-04 * Fastmail subscription
+  expenses:software:email               $38.99
+  assets:bank:checking                 -$38.99
+
+2025-03-07 * App Store sale
+  assets:bank:checking                   $2.47
+  income:sales:apple                    -$2.47
+
+2025-03-07 * Maine Annual LLC Filing
+  expenses:professional:compliance   $185.00
+  equity:owner:contributions        -$185.00
+
+2025-03-08 * Pragmatic Engineer subscription
+  expenses:education                    $15.00
+  assets:bank:checking                 -$15.00
+
+2025-03-27 * GitHub subscription
+  expenses:software:github               $4.00
+  assets:bank:checking                  -$4.00
+
+2025-03-31 * Reconciled - March 2025
+  ; assets:bank:checking matched statement balance of $93.16
+  ; reconciliation completed Tue Apr 22 10:33:05 EDT 2025


### PR DESCRIPTION
## Summary
- Added new command to sort hledger journal entries chronologically by date
- Preserves transaction integrity and leading comments
- Accessible via Shift+Cmd+S keyboard shortcut

## Changes
- Implemented `sortHledgerJournal()` function to sort transactions by date
- Added `parseTransactionsWithLeading()` to properly parse and preserve leading content
- Registered new VS Code command `hledger-formatter.sortEntries`
- Added comprehensive test coverage for sorting functionality
- Updated documentation in CLAUDE.md

## Test plan
- [x] Run `npm test` to verify all tests pass
- [x] Test sorting with mixed date orders
- [x] Verify preservation of leading comments
- [x] Confirm transaction integrity is maintained
- [x] Test with various date formats (YYYY-MM-DD, YYYY/MM/DD)

🤖 Generated with [Claude Code](https://claude.ai/code)