### PR TITLE
feat: Add configurable amount column position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 ### Added
+- Configurable amount column position with `hledger-formatter.amountColumnPosition` setting (closes #16)
+  - Default: 42 (preserves existing behavior)
+  - Range: 20-100 for flexible alignment preferences
 - Sort-on-save option for automatic journal sorting (closes #10)
 - New file command to create monthly journal files with Cmd+N (closes #4)
 - Sort journal entries by date command with Shift+Cmd+S (closes #1)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,12 @@ This is a VS Code extension called "hledger-formatter" that formats hledger jour
 
 ### Formatting Logic
 
-The formatter aligns all amounts to a fixed column position (42 characters from left):
+The formatter aligns all amounts to a configurable column position (default: 42 characters from left):
 - Uses exactly 2 spaces for posting line indentation
 - Handles negative amounts by converting `$-X.XX` to `-$X.XX` format
 - Preserves comments and transaction structure
 - Normalizes transaction header spacing
+- Column position is configurable via `hledger-formatter.amountColumnPosition` setting
 
 ### Comment Toggle Logic
 
@@ -206,10 +207,11 @@ Test verification includes:
 The extension provides the following settings:
 - `hledger-formatter.formatOnSave` (boolean, default: true) - Auto-format on file save
 - `hledger-formatter.sortOnSave` (boolean, default: true) - Sort journal entries by date on save
+- `hledger-formatter.amountColumnPosition` (number, default: 42, range: 20-100) - Column position for aligning amounts
 
 ## Key Implementation Details
 
-- Fixed amount column alignment at position 42
+- Configurable amount column alignment (default position: 42)
 - Negative amount format standardization
 - Transaction boundary detection using date regex: `/^\d{4}[/-]\d{2}[/-]\d{2}/`
 - Supports transaction status markers (`*`, `!`)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This extension contributes the following settings:
 
 * `hledger-formatter.formatOnSave`: Enable/disable formatting on save (default: true)
 * `hledger-formatter.sortOnSave`: Enable/disable sorting entries by date on save (default: true)
+* `hledger-formatter.amountColumnPosition`: Column position for aligning amounts (default: 42, range: 20-100)
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,13 @@
           "type": "boolean",
           "default": true,
           "description": "Sort hledger journal entries by date on save"
+        },
+        "hledger-formatter.amountColumnPosition": {
+          "type": "number",
+          "default": 42,
+          "minimum": 20,
+          "maximum": 100,
+          "description": "Column position for aligning amounts (default: 42)"
         }
       }
     },

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -372,6 +372,59 @@ suite('Hledger Formatter Tests', () => {
 		}
 	});
 
+	test('Format with custom column position', () => {
+		// Test input with transactions
+		const testInput = `2025-03-01 Test transaction
+  Assets:Cash  $100.00
+  Income:Salary       -$100.00
+
+2025-03-02 Another transaction  
+  Expenses:Food    $25.50
+  Assets:Cash   -$25.50`;
+
+		// Test with column position 30
+		const formatted30 = formatHledgerJournal(testInput, 30);
+		const lines30 = formatted30.split('\n');
+		
+		// Verify amounts are aligned at column 30
+		const amountLines30 = lines30.filter(line => line.includes('$'));
+		for (const line of amountLines30) {
+			const dollarIndex = line.indexOf('$');
+			// Check for negative amounts (-$) vs regular ($)
+			const actualIndex = line.includes('-$') ? line.indexOf('-$') + 1 : dollarIndex;
+			assert.ok(actualIndex >= 28 && actualIndex <= 32, 
+				`Amount should be aligned around column 30, got ${actualIndex}: ${line}`);
+		}
+		
+		// Test with column position 50
+		const formatted50 = formatHledgerJournal(testInput, 50);
+		const lines50 = formatted50.split('\n');
+		
+		// Verify amounts are aligned at column 50
+		const amountLines50 = lines50.filter(line => line.includes('$'));
+		for (const line of amountLines50) {
+			const dollarIndex = line.indexOf('$');
+			// Check for negative amounts (-$) vs regular ($)
+			const actualIndex = line.includes('-$') ? line.indexOf('-$') + 1 : dollarIndex;
+			assert.ok(actualIndex >= 48 && actualIndex <= 52, 
+				`Amount should be aligned around column 50, got ${actualIndex}: ${line}`);
+		}
+		
+		// Test with default column position (42)
+		const formattedDefault = formatHledgerJournal(testInput);
+		const linesDefault = formattedDefault.split('\n');
+		
+		// Verify amounts are aligned at column 42 (default)
+		const amountLinesDefault = linesDefault.filter(line => line.includes('$'));
+		for (const line of amountLinesDefault) {
+			const dollarIndex = line.indexOf('$');
+			// Check for negative amounts (-$) vs regular ($)
+			const actualIndex = line.includes('-$') ? line.indexOf('-$') + 1 : dollarIndex;
+			assert.ok(actualIndex >= 40 && actualIndex <= 44, 
+				`Amount should be aligned around column 42 (default), got ${actualIndex}: ${line}`);
+		}
+	});
+
 	test('Sort preserves comments at beginning', () => {
 		const testInput = `; File header comment
 ; This should stay at the top


### PR DESCRIPTION
## Summary
- Implements issue #16 - makes whitespace length in formatter configurable
- Adds new configuration setting `hledger-formatter.amountColumnPosition`
- Preserves backward compatibility with default value of 42

## Changes
- Added configuration setting in `package.json` with default value of 42 (range: 20-100)
- Updated `formatHledgerJournal()` to accept optional column position parameter
- Modified `formatTransaction()` to use configurable column position
- All formatting commands now read and use the configuration value
- Added comprehensive tests for custom column positions
- Updated documentation in README.md and CLAUDE.md

## Test Plan
- [x] All existing tests pass
- [x] New test "Format with custom column position" validates functionality at positions 30, 50, and default (42)
- [x] Manually tested with different column positions
- [x] Verified backward compatibility (default value preserves existing behavior)

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)