### PR TITLE
Fix VS Code Marketplace URL publisher ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For help and support, see [SUPPORT.md](SUPPORT.md)
 
 - **Issues & Bug Reports**: [GitHub Issues](https://github.com/iiAtlas/hledger-formatter/issues)
 - **Source Code**: [GitHub Repository](https://github.com/iiAtlas/hledger-formatter)
-- **VS Code Marketplace**: [hledger-formatter](https://marketplace.visualstudio.com/items?itemName=iiAtlas.hledger-formatter)
+- **VS Code Marketplace**: [hledger-formatter](https://marketplace.visualstudio.com/items?itemName=iiatlas.hledger-formatter)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Fixed the VS Code Marketplace URL in README.md to use the correct publisher ID
- Changed from `iiAtlas` to `iiatlas` (lowercase)

## Changes
- Updated marketplace URL from `itemName=iiAtlas.hledger-formatter` to `itemName=iiatlas.hledger-formatter`

## Test plan
- [x] Verified the correct URL works: https://marketplace.visualstudio.com/items?itemName=iiatlas.hledger-formatter
- [x] README displays correctly with updated link

🤖 Generated with [Claude Code](https://claude.ai/code)