### PR TITLE
Fix transaction headers incorrectly preserving leading whitespace

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -690,7 +690,6 @@ function formatTransactionHeader(headerLine: string, options: FormatterOptions):
 	const commentIndex = headerLine.search(commentRegex);
 	const commentPart = commentIndex !== -1 ? headerLine.slice(commentIndex) : '';
 	const headerWithoutComment = commentIndex !== -1 ? headerLine.slice(0, commentIndex) : headerLine;
-	const leadingWhitespace = headerWithoutComment.match(/^\s*/)?.[0] ?? '';
 	const trimmedHeader = headerWithoutComment.trim();
 	if (!trimmedHeader) {
 		return headerLine;
@@ -731,7 +730,8 @@ function formatTransactionHeader(headerLine: string, options: FormatterOptions):
 		segments.push(description);
 	}
 
-	const baseHeader = `${leadingWhitespace}${segments.join(' ')}`;
+	// Transaction headers should always start at column 0 (no leading whitespace)
+	const baseHeader = segments.join(' ');
 	if (!commentPart) {
 		return baseHeader;
 	}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -51,27 +51,54 @@ suite('Hledger Formatter Tests', () => {
 		// Read input and expected output files
 		const inputJournal = readTestFile('inconsistent_indents_in.journal');
 		const expectedOutput = readTestFile('inconsistent_indents_out.journal');
-		
+
 		// Format the input journal
 		const formattedJournal = formatHledgerJournal(inputJournal);
-		
+
 		// Normalize both texts to handle line endings and whitespace
 		const normalizedFormatted = normalizeText(formattedJournal);
 		const normalizedExpected = normalizeText(expectedOutput);
-		
+
 		// Verify the formatting matches the expected output
-		assert.strictEqual(normalizedFormatted, normalizedExpected, 
+		assert.strictEqual(normalizedFormatted, normalizedExpected,
 			'Formatted output with inconsistent indentation should match expected output');
-		
+
 		// Verify indentation correction
 		const correctIndentation = verifyIndentation(formattedJournal);
-		assert.strictEqual(correctIndentation, true, 
+		assert.strictEqual(correctIndentation, true,
 			'All posting lines should have exactly 2 spaces of indentation');
-		
+
 		// Verify decimal point alignment
 		const decimalPointsAligned = verifyDecimalPointsAligned(formattedJournal);
-		assert.strictEqual(decimalPointsAligned, true, 
+		assert.strictEqual(decimalPointsAligned, true,
 			'Decimal points should be aligned in each transaction');
+	});
+
+	test('Format transaction headers with leading spaces', () => {
+		// Read input and expected output files
+		const inputJournal = readTestFile('header_indented_in.journal');
+		const expectedOutput = readTestFile('header_indented_out.journal');
+
+		// Format the input journal
+		const formattedJournal = formatHledgerJournal(inputJournal);
+
+		// Normalize both texts to handle line endings and whitespace
+		const normalizedFormatted = normalizeText(formattedJournal);
+		const normalizedExpected = normalizeText(expectedOutput);
+
+		// Verify the formatting matches the expected output
+		assert.strictEqual(normalizedFormatted, normalizedExpected,
+			'Transaction headers should not have leading spaces');
+
+		// Verify transaction headers start at column 0
+		const lines = formattedJournal.split('\n');
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+			if (/^\d{4}[-/]\d{2}[-/]\d{2}/.test(line)) {
+				assert.ok(!line.startsWith(' '),
+					`Transaction header at line ${i+1} should not have leading spaces: "${line}"`);
+			}
+		}
 	});
 	
 	test('Format sample journal with negative amounts', () => {

--- a/src/test/test_journals/header_indented_in.journal
+++ b/src/test/test_journals/header_indented_in.journal
@@ -1,0 +1,10 @@
+; Test file with indented transaction headers (issue reported by user)
+
+  2025-09-02 * Stripe payout
+  ; Stripe ACH deposit
+  assets:checking $100.00
+  income:stripe -$100.00
+
+  2025-09-05 * Another transaction
+    expenses:software  $50.00
+    assets:checking   -$50.00

--- a/src/test/test_journals/header_indented_out.journal
+++ b/src/test/test_journals/header_indented_out.journal
@@ -1,0 +1,10 @@
+; Test file with indented transaction headers (issue reported by user)
+
+2025-09-02 * Stripe payout
+  ; Stripe ACH deposit
+    assets:checking  $100.00
+    income:stripe   $-100.00
+
+2025-09-05 * Another transaction
+    expenses:software  $50.00
+    assets:checking   $-50.00


### PR DESCRIPTION
Fixed an issue where transaction headers (date lines) were preserving leading whitespace from the input, causing them to be indented when they should always start at column 0.

Changes:
- Remove leading whitespace preservation in formatTransactionHeader() (src/extension.ts:671, 712)
- Add test case for transaction headers with leading spaces (src/test/test_journals/header_indented_*.journal)
- Add test in extension.test.ts to verify transaction headers start at column 0

Fixes issue where formatter was outputting:
  2025-09-02 * Stripe payout

Instead of correct output:
2025-09-02 * Stripe payout

🤖 Generated with [Claude Code](https://claude.com/claude-code)