### PR TITLE
feat: support syntax-highlighting for arbitrary depth accounts

### DIFF
--- a/syntaxes/hledger.tmLanguage.json
+++ b/syntaxes/hledger.tmLanguage.json
@@ -151,24 +151,17 @@
         },
         {
           "name": "meta.posting.hledger",
-          "match": "^\\s+(([^:;#*\\s]+)(?::([^:;#*\\s]+)(?::([^:;#*\\s]+)(?::([^:;#*\\s]+)(?::([^:;#*\\s]+))?)?)?)?(?:\\s+([^;#*]+))?(\\s*[;#*].*)?$)",
+          "match": "^\\s+(([^;#*\\s]+)(?:\\s+([^;#*]+))?(\\s*[;#*].*)?$)",
           "captures": {
             "2": {
-              "name": "entity.name.tag.account.level1.hledger"
+              "name": "meta.account.hledger",
+              "patterns": [
+                {
+                  "include": "#account"
+                }
+              ]
             },
             "3": {
-              "name": "entity.name.function.account.level2.hledger"
-            },
-            "4": {
-              "name": "variable.parameter.account.level3.hledger"
-            },
-            "5": {
-              "name": "storage.type.account.level4.hledger"
-            },
-            "6": {
-              "name": "keyword.control.account.level5.hledger"
-            },
-            "7": {
               "name": "meta.amount.hledger",
               "patterns": [
                 {
@@ -176,8 +169,33 @@
                 }
               ]
             },
-            "8": {
+            "4": {
               "name": "comment.line.inline.hledger"
+            }
+          }
+        }
+      ]
+    },
+    "account": {
+      "name": "meta.account.hledger",
+      "patterns": [
+        {
+          "match": "(?:([^:]+):?)?(?:([^:]+):?)?(?:([^:]+):?)?(?:([^:]+):?)?(?:([^:]+):?)?",
+          "captures": {
+            "1": {
+              "name": "entity.name.tag.account.level1.hledger"
+            },
+            "2": {
+              "name": "entity.name.function.account.level2.hledger"
+            },
+            "3": {
+              "name": "variable.parameter.account.level3.hledger"
+            },
+            "4": {
+              "name": "storage.type.account.level4.hledger"
+            },
+            "5": {
+              "name": "keyword.control.account.level5.hledger"
             }
           }
         }


### PR DESCRIPTION
Adds syntax highlighting for arbitrary-depth accounts (>5 sub-accounts) by allowing the pattern to wrap and match each contiguous sequence of 5 sub-accounts.

| Before | After |
|--------|--------|
| <img width="584" height="58" alt="image" src="https://github.com/user-attachments/assets/218a7f89-8746-4e73-a140-9929dd716d3b" />| <img width="584" height="60" alt="image" src="https://github.com/user-attachments/assets/619ac96e-43b9-4055-9f2d-4b725f642b02" /> | 

### Changes:
- adds `account` rule to the `hledger` textmate grammar. Line anchors are removed from existing pattern to allow matching additional sub-strings following the 5th sub-account, pretty similar to [Rainbow CSV](https://github.com/mechatroner/vscode_rainbow_csv/blob/master/syntaxes/csv.tmLanguage.json#L5)
- updates `posting` rule to have nested pattern that includes the above `account` rule.