### PR TITLE
fix: support all valid commodity formats

### DIFF
--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -897,6 +897,62 @@ suite('Hledger Formatter Tests', () => {
 		assert.strictEqual(result, null, 'Should return null for invalid format');
 	});
 
+	test('parseAmount - simple commodity name', () => {
+		const result = parseAmount('USD 0.5');
+		assert.ok(result, 'Should parse simple commodity name');
+		assert.strictEqual(result?.value, 0.5);
+		assert.strictEqual(result?.currency, 'USD');
+	});
+
+	test('parseAmount - negative before simple commodity name', () => {
+		const result = parseAmount('-USD 50.25');
+		assert.ok(result, 'Should parse negative with arbitrary commodity name');
+		assert.strictEqual(result?.value, -50.25);
+		assert.strictEqual(result?.currency, 'USD');
+	});
+
+	test('parseAmount - quoted commodity name', () => {
+		const result = parseAmount('"US Dollar" 100.00');
+		assert.ok(result, 'Should parse quoted commodity name');
+		assert.strictEqual(result?.value, 100.00);
+		assert.strictEqual(result?.currency, '"US Dollar"');
+	});
+
+	test('parseAmount - negative sign before quoted commodity name', () => {
+		const result = parseAmount('-"US Dollar" 100.00');
+		assert.ok(result, 'Should parse negative sign before quoted commodity name');
+		assert.strictEqual(result?.value, -100.00);
+		assert.strictEqual(result?.currency, '"US Dollar"');
+	});
+
+	test('parseAmount - number before simple commodity name', () => {
+		const result = parseAmount('100.50 USD');
+		assert.ok(result, 'Should parse number before commodity name');
+		assert.strictEqual(result?.value, 100.50);
+		assert.strictEqual(result?.currency, 'USD');
+	});
+
+	test('parseAmount - negative number before simple commodity name', () => {
+		const result = parseAmount('-100.50 USD');
+		assert.ok(result, 'Should parse negative number before commodity name');
+		assert.strictEqual(result?.value, -100.50);
+		assert.strictEqual(result?.currency, 'USD');
+	});
+
+	test('parseAmount - number before quoted commodity name', () => {
+		const result = parseAmount('100.00 "US Dollar"');
+		assert.ok(result, 'Should parse number before quoted commodity name');
+		assert.strictEqual(result?.value, 100.00);
+		assert.strictEqual(result?.currency, '"US Dollar"');
+	});
+
+	test('parseAmount - negative number before quoted commodity name', () => {
+		const result = parseAmount('-100.00 "US Dollar"');
+		assert.ok(result, 'Should parse negative number before quoted commodity name');
+		assert.strictEqual(result?.value, -100.00);
+		assert.strictEqual(result?.currency, '"US Dollar"');
+	});
+
 	test('formatAmountValue - positive with symbolBeforeSign', () => {
 		const result = formatAmountValue(100.50, '$', 'symbolBeforeSign');
 		assert.strictEqual(result, '$100.50');
@@ -915,6 +971,16 @@ suite('Hledger Formatter Tests', () => {
 	test('formatAmountValue - large amount with commas', () => {
 		const result = formatAmountValue(1234.56, '$', 'symbolBeforeSign');
 		assert.strictEqual(result, '$1,234.56');
+	});
+
+	test('formatAmountValue - simple commodity name', () => {
+		const result = formatAmountValue(100.50, 'USD', 'symbolBeforeSign');
+		assert.strictEqual(result, 'USD100.50');
+	});
+
+	test('formatAmountValue - quoted commodity name', () => {
+		const result = formatAmountValue(100.50, '"US Dollar"', 'symbolBeforeSign');
+		assert.strictEqual(result, '"US Dollar"100.50');
 	});
 
 	test('calculateBalancingAmount - simple two posting transaction', () => {

--- a/syntaxes/hledger.tmLanguage.json
+++ b/syntaxes/hledger.tmLanguage.json
@@ -186,20 +186,20 @@
     "amount": {
       "patterns": [
         {
-          "name": "constant.numeric.currency.hledger",
-          "match": "[-]?\\$[-]?[0-9]+(?:[.,][0-9]+)?",
+          "name": "constant.numeric.amount.hledger",
+          "match": "[-]?(\"[^;\"]+\"|[^\\d\\-+.@*;\\t \"{}=]+)\\s*[-]?[0-9]+(?:[.,][0-9]+)?",
           "captures": {
-            "0": {
-              "name": "constant.numeric.amount.hledger"
+            "1": {
+              "name": "constant.numeric.commodity.hledger"
             }
           }
         },
         {
           "name": "constant.numeric.amount.hledger",
-          "match": "[-]?[0-9]+(?:[.,][0-9]+)?(?:\\s+[A-Z]{3,})?",
+          "match": "[-]?[0-9]+(?:[.,][0-9]+)?(?:\\s*(\"[^;\"]+\"|[^\\d\\-+.@*;\\t \"{}=]+))?",
           "captures": {
-            "0": {
-              "name": "constant.numeric.amount.hledger"
+            "1": {
+              "name": "constant.numeric.commodity.hledger"
             }
           }
         }


### PR DESCRIPTION
### Changes:
#### Screenshots:
| Before | After |
|--------|--------|
| <img width="315" height="461" alt="image" src="https://github.com/user-attachments/assets/07d8dcfe-193a-4e98-bdcf-21a163921305" />| <img width="316" height="463" alt="image" src="https://github.com/user-attachments/assets/6afc886a-ae2d-4c35-ba7a-1cdfcfb39165" /> |  

(note: a custom color is applied to the `constant.numeric.commodity.hledger` token just to indicate the difference in the screenshots) 
#### Summary:
- expands textmate grammar and amount-parsing logic to handle all valid commodity specifiers in the amount on postings
  - commodities with 1 or 2 characters
  -  commodities with non-alphabetic characters:
      - quoted values: `hledger` allows every character other than `;`, `\n`, and `"` to appear in a commodity name if wrapped in quotes ([source](https://github.com/simonmichael/hledger/blob/d97fa51b65030eb4d74afbb88a3288f0f0ef453d/hledger-lib/Hledger/Read/Common.hs#L971-L973))
      - simple values (unquoted): `hledger` allows any character other than digits, `-`, `+`, `@`, `*`, `;`, `\t`, `\n`, ` `, `"`, `{`, `}`, and `=` to appear in unquoted commodity names ([source](https://github.com/simonmichael/hledger/blob/d97fa51b65030eb4d74afbb88a3288f0f0ef453d/hledger-lib/Hledger/Data/Amount.hs#L222-L226))