### PR TITLE
fix: syntax highlighting for account name and amount to match Hledger support

### DIFF
--- a/syntaxes/hledger.tmLanguage.json
+++ b/syntaxes/hledger.tmLanguage.json
@@ -151,7 +151,7 @@
         },
         {
           "name": "meta.posting.hledger",
-          "match": "^\\s+(([^;#*]+?)\\s{2,}([\\S\\s]+?)(?:\\s+([;#*].*))?$)",
+          "match": "^\\s+(([^;#*]+?)(?:\\s{2,}([\\S\\s]+?))?(?:\\s+([;#*].*))?)$",
           "captures": {
             "2": {
               "name": "meta.account.hledger",


### PR DESCRIPTION
- Fixed account name regexes to support single spaces. 
- Fixed amount regex to support sign formats, indian numeric system, thousand separators, and cost syntax.
- Fixed posting regex to handle above changes